### PR TITLE
Add a dev settings with django_extensions enabled

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.base")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.dev")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,3 +8,4 @@ isort
 pytest-cov
 pytest-django
 codacy-coverage
+django-extensions

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -1,0 +1,7 @@
+from .base import *  # noqa
+
+DEBUG = True
+
+INSTALLED_APPS += [
+    'django_extensions',
+]

--- a/settings/dev.py
+++ b/settings/dev.py
@@ -2,6 +2,6 @@ from .base import *  # noqa
 
 DEBUG = True
 
-INSTALLED_APPS += [
+INSTALLED_APPS += [  # noqa: F405
     'django_extensions',
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
-django_find_project = false
 python_files = tests.py test_*.py *_tests.py
+DJANGO_SETTINGS_MODULE = settings.test
 
 [wheel]
 universal = 1


### PR DESCRIPTION
* Add a settings file for development that has `django_extensions` enabled
* Fix tests to use proper settings (`settings.test`)
